### PR TITLE
Fixing hierarchy of html and logic elements in sidebar

### DIFF
--- a/_data/toc.yml
+++ b/_data/toc.yml
@@ -15,7 +15,7 @@
       children:
         - title: Quizzes
           url: "docs/extras/example-quiz"
-    - title: "About"
-      url: "about"
-    - title: "News"
-      url: "news"
+- title: "About"
+  url: "about"
+- title: "News"
+  url: "news"

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -5,18 +5,34 @@
     </button>
   </form>  
   <nav class="collapse td-sidebar-nav pt-2 pl-4" id="td-section-nav">
-{% for section in site.data.toc %}<ul class="td-sidebar-nav__section pr-md-3">
+  <ul class="td-sidebar-nav__section pr-md-3">
+{% for section in site.data.toc %}
   <li class="td-sidebar-nav__section-title">
     <a  href="{% if section.url %}{{ site.baseurl }}/{{ section.url }}{% else %}{{ section.external_url }}{% endif %}" class="align-left pl-0 pr-2 active td-sidebar-link td-sidebar-link__section">{{ section.title }}</a>
-  </li>{% if section.links %}<ul>
-    <li class="collapse show" id="{{ section.title | slugify }}">
-        <ul class="td-sidebar-nav__section pr-md-3">{% for entry in section.links %}
-          <li class="td-sidebar-nav__section-title">
-            <a href="{% if entry.url %}{{ site.baseurl }}/{{ entry.url }}{% else %}{{ entry.external_url }}{% endif %}" class="align-left pl-0 pr-2 td-sidebar-link td-sidebar-link__section">{{ entry.title }}</a>
-          </li>
-          <ul><li class="collapse show" id="{{ child.title | slugify }}">{% if entry.children %}
-              {% for child in entry.children %}<a class="td-sidebar-link td-sidebar-link__page " id="m-{{ section.title | slugify }}-{{ entry.title | slugify }}-{{ child.title | slugify }}" href="{% if child.url %}{{ site.baseurl }}/{{ child.url }}{% else %}{{ child.external_url }}{% endif %}">{{ child.title }}</a>{% endfor %}
-              {% endif %}</li></ul>{% endfor %}
-    </ul>{% endif %}{% endfor %}
+  </li>
+  {% if section.links %}
+	  <ul>
+	  {% for entry in section.links %}
+		<li class="collapse show" id="{{ section.title | slugify }}">
+			<ul class="td-sidebar-nav__section pr-md-3">
+			  <li class="td-sidebar-nav__section-title">
+				<a href="{% if entry.url %}{{ site.baseurl }}/{{ entry.url }}{% else %}{{ entry.external_url }}{% endif %}" class="align-left pl-0 pr-2 td-sidebar-link td-sidebar-link__section">{{ entry.title }}</a>
+			  </li>
+			  <ul>
+				  {% if entry.children %}
+				  <li class="collapse show" id="{{ child.title | slugify }}">
+					  {% for child in entry.children %}
+						<a class="td-sidebar-link td-sidebar-link__page " id="m-{{ section.title | slugify }}-{{ entry.title | slugify }}-{{ child.title | slugify }}" href="{% if child.url %}{{ site.baseurl }}/{{ child.url }}{% else %}{{ child.external_url }}{% endif %}">{{ child.title }}</a>
+					  {% endfor %}			  
+				  </li>
+				  {% endif %}
+			  </ul>
+			</ul>
+		</li>
+	  {% endfor %}
+	  </ul>
+  {% endif %}
+{% endfor %}
+</ul>
   </nav>
 </div>


### PR DESCRIPTION
I don't know if it  was reported before, but I think I've found a bug. Opening the PR with the solution.

**Problem:** When adding a new section in the toc.yml, the hierarchy of html elements at the sidebar breaks.

**Steps to test it:** add a new element in "root" level at toc.yml. The second will appear inside de li element.

**Solution:** identing the code, opening and closing the html elements in (what I think is) the correct order