### PR TITLE
fix URL's top level domain

### DIFF
--- a/pages/about.md
+++ b/pages/about.md
@@ -5,7 +5,7 @@ permalink: /about/
 
 # About
 
-This is a [starter template](https://vsoch.github.com/docsy-jekyll/) for a Docsy jekyll theme, based
+This is a [starter template](https://vsoch.github.io/docsy-jekyll/) for a Docsy jekyll theme, based
 on the Beautiful [Docsy](https://github.com/google/docsy) that renders with Hugo. This version is intended for
 native deployment on GitHub pages. See the [respository]({{ site.repo }}) for more details.
 


### PR DESCRIPTION
GitHub Pages' domain is `.io`, not `.com`.