### PR TITLE
adding spell check for docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,16 @@
+name: check-spelling
+
+on:
+  push:
+    branches: [master]
+  pull_request: []
+
+jobs:
+  formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check for typos
+        uses: crate-ci/typos@592b36d23c62cb378f6097a292bc902ee73f93ef # version 1.0.4
+        with: 
+          files: ./README.md ./_docs ./pages ./_posts

--- a/_docs/getting-started.md
+++ b/_docs/getting-started.md
@@ -153,7 +153,7 @@ If you want to add an external url for a parent or child, do this:
 ### News Posts
 
 It might be the case that your site or group has news items that would
-warrent sharing with the community, and should be available as a feed.
+warrant sharing with the community, and should be available as a feed.
 For this reason, you can write traditional [posts](https://jekyllrb.com/docs/posts/) in the `_posts`
 folder that will parse into the site [feed]({{ site.baseurl }}/feed.xml)
 The bottom of the page links the user to a post archive, where posts are organized
@@ -321,7 +321,7 @@ should follow the instructions to [set up a project](https://circleci.com/docs/e
 and then in the project settings be sure to enable building forked build requests,
 and to cancel redundant builds. The preview will be built on CircleCI, and saved
 to static files for you to browse. The only change you will need is to edit
-the static files location to be the name of your respository, which is at te
+the static files location to be the name of your repository, which is at te
 bottom of the `.circleci/config.yml` file:
 
 ```yaml

--- a/pages/about.md
+++ b/pages/about.md
@@ -7,7 +7,7 @@ permalink: /about/
 
 This is a [starter template](https://vsoch.github.io/docsy-jekyll/) for a Docsy jekyll theme, based
 on the Beautiful [Docsy](https://github.com/google/docsy) that renders with Hugo. This version is intended for
-native deployment on GitHub pages. See the [respository]({{ site.repo }}) for more details.
+native deployment on GitHub pages. See the [repository]({{ site.repo }}) for more details.
 
 ## Support
 


### PR DESCRIPTION
I noticed spelling errors (that have persisted for a while!) in #69, so this will be useful to the user to always check spelling. It will go out with the WIP 0.0.25 release to add versioning.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>