### PR TITLE
Add integrity hash for jquery running on Windows

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -38,6 +38,6 @@
 <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/palette.css">
 <script
   src="{{ site.baseurl }}/assets/js/jquery-3.3.1/jquery-3.3.1.min.js"
-  integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
+  integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8= sha256-T+aPohYXbm0fRYDpJLr+zJ9RmYTswGsahAoIsNiMld4="
   crossorigin="anonymous"></script>
 </head>

--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -1,6 +1,6 @@
 <script
   src="{{ site.baseurl }}/assets/js/jquery-3.3.1/jquery-3.3.1.min.js"
-  integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
+  integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8= sha256-T+aPohYXbm0fRYDpJLr+zJ9RmYTswGsahAoIsNiMld4="
   crossorigin="anonymous"></script>
 
 <script>


### PR DESCRIPTION
This PR fixes a bug that causes search to break when running locally on Windows. It does this by adding the integrity hash for jquery-3.3.1.min.js when it is checked out with Windows-style line endings.   

Close #71 